### PR TITLE
Use model._base_manager instead of model.objects

### DIFF
--- a/computedfields/admin.py
+++ b/computedfields/admin.py
@@ -166,7 +166,7 @@ class ComputedModelsAdmin(admin.ModelAdmin):
         Render modelgraph view.
         """
         try:
-            inst = self.model.objects.get(pk=modelid)
+            inst = self.model._base_manager.get(pk=modelid)
             model = apps.get_model(inst.app_label, inst.model)
         except ObjectDoesNotExist:
             error = 'illegal value for model'

--- a/computedfields/graph.py
+++ b/computedfields/graph.py
@@ -650,8 +650,8 @@ class ComputedModelsGraph(Graph):
 
         .. code:: python
 
-            qs = target_model.objects.filter(filter_string=src_model.instance)
-            qs |= target_model.objects.filter(filter_string2=src_model.instance)
+            qs = target_model._base_manager.filter(filter_string=src_model.instance)
+            qs |= target_model._base_manager.filter(filter_string2=src_model.instance)
             ...
             bulk_updater(qs, cf_fields)
 

--- a/computedfields/handlers.py
+++ b/computedfields/handlers.py
@@ -115,7 +115,7 @@ def postdelete_handler(sender: Type[Model], instance: Model, **kwargs) -> None:
         with transaction.atomic():
             for model, [pks, fields] in updates.items():
                 active_resolver.bulk_updater(
-                    model.objects.filter(pk__in=pks),
+                    model._base_manager.filter(pk__in=pks),
                     fields,
                     querysize=settings.COMPUTEDFIELDS_QUERYSIZE
                 )
@@ -146,7 +146,7 @@ def merge_qs_maps(
     Updates obj1 inplace and also returns it.
     """
     for model, [qs2, fields2] in obj2.items():
-        query_field = obj1.setdefault(model, [model.objects.none(), set()])
+        query_field = obj1.setdefault(model, [model._base_manager.none(), set()])
         query_field[0] |= qs2            # or'ed querysets
         query_field[1].update(fields2)   # add fields
     return obj1
@@ -181,7 +181,7 @@ def m2m_handler(sender: Type[Model], instance: Model, **kwargs) -> None:
         data_add: Dict[Type[Model], List[Any]] = active_resolver._querysets_for_update(
             type(instance), instance, update_fields={left})
         other_add: Dict[Type[Model], List[Any]] = active_resolver._querysets_for_update(
-            model, model.objects.filter(pk__in=pks_add), update_fields={right})
+            model, model._base_manager.filter(pk__in=pks_add), update_fields={right})
         if other_add:
             merge_qs_maps(data_add, other_add)
         if data_add:
@@ -198,7 +198,7 @@ def m2m_handler(sender: Type[Model], instance: Model, **kwargs) -> None:
         data_remove: Dict[Type[Model], List[Any]] = active_resolver._querysets_for_update(
             type(instance), instance, update_fields={left}, pk_list=True)
         other_remove: Dict[Type[Model], List[Any]] = active_resolver._querysets_for_update(
-            model, model.objects.filter(pk__in=pks_remove), update_fields={right}, pk_list=True)
+            model, model._base_manager.filter(pk__in=pks_remove), update_fields={right}, pk_list=True)
         if other_remove:
             merge_pk_maps(data_remove, other_remove)
         if data_remove:
@@ -210,7 +210,7 @@ def m2m_handler(sender: Type[Model], instance: Model, **kwargs) -> None:
             with transaction.atomic():
                 for _model, [pks, update_fields] in updates_remove.items():
                     active_resolver.bulk_updater(
-                        _model.objects.filter(pk__in=pks),
+                        _model._base_manager.filter(pk__in=pks),
                         update_fields,
                         querysize=settings.COMPUTEDFIELDS_QUERYSIZE
                     )
@@ -231,7 +231,7 @@ def m2m_handler(sender: Type[Model], instance: Model, **kwargs) -> None:
             with transaction.atomic():
                 for _model, [pks, update_fields] in updates_clear.items():
                     active_resolver.bulk_updater(
-                        _model.objects.filter(pk__in=pks),
+                        _model._base_manager.filter(pk__in=pks),
                         update_fields,
                         querysize=settings.COMPUTEDFIELDS_QUERYSIZE
                     )

--- a/computedfields/management/commands/checkdata.py
+++ b/computedfields/management/commands/checkdata.py
@@ -78,7 +78,7 @@ class Command(BaseCommand):
     def action_check(self, models, progress, size, json_out):
         has_desync = False
         for model in models:
-            qs = model.objects.all()
+            qs = model._base_manager.all()
             amount = qs.count()
             fields = set(active_resolver.computed_models[model].keys())
             qsize = active_resolver.get_querysize(model, fields, size)

--- a/computedfields/management/commands/updatedata.py
+++ b/computedfields/management/commands/updatedata.py
@@ -99,12 +99,12 @@ class Command(BaseCommand):
                 with tqdm(total=amount, desc='  Update', unit=' rec') as bar:
                     pos = 0
                     while pos < amount:
-                        active_resolver.update_dependent(model.objects.filter(pk__in=desync[pos:pos+qsize]))
+                        active_resolver.update_dependent(model._base_manager.filter(pk__in=desync[pos:pos+qsize]))
                         progressed = min(pos+qsize, amount) - pos
                         bar.update(progressed)
                         pos += qsize
             else:
-                active_resolver.update_dependent(model.objects.filter(pk__in=desync))
+                active_resolver.update_dependent(model._base_manager.filter(pk__in=desync))
 
     @transaction.atomic
     def action_default(self, models, size, show_progress, mode=''):
@@ -118,7 +118,7 @@ class Command(BaseCommand):
         print(f'Default querysize: {size}')
         print('Models:')
         for model in models:
-            qs = model.objects.all()
+            qs = model._base_manager.all()
             amount = qs.count()
             fields = set(active_resolver.computed_models[model].keys())
             print(f'- {self.style.MIGRATE_LABEL(modelname(model))}')
@@ -179,7 +179,7 @@ class Command(BaseCommand):
             from django.conf import settings as ds
             ds.COMPUTEDFIELDS_QUERYSIZE = size
         for model in models:
-            qs = model.objects.all()
+            qs = model._base_manager.all()
             amount = qs.count()
             fields = list(active_resolver.computed_models[model].keys())
             qsize = active_resolver.get_querysize(model, fields, size)


### PR DESCRIPTION
Some applications will have overridden models.objects with a custom manager that excludes some records by default. Use _base_manager manager to ensure that all db rows are considered